### PR TITLE
Upgrade to RC2 / dotnet-cli

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,45 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceRoot}/bin/Debug/netcoreapp1.0/AspNetCorePostgreSQLDockerApp.dll",
+            "args": [],
+            "cwd": "${workspaceRoot}",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceRoot}/bin/Debug/netcoreapp1.0/AspNetCorePostgreSQLDockerApp.dll",
+            "args": [],
+            "cwd": "${workspaceRoot}",
+            "stopAtEntry": false,
+            "launchBrowser": {
+                "enabled": true,
+                "args": "${auto-detect-url}",
+                "windows": {
+                    "command": "cmd.exe",
+                    "args": "/C start ${auto-detect-url}"
+                },
+                "osx": {
+                    "command": "open"
+                },
+                "linux": {
+                    "command": "xdg-open"
+                }
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processName": "<example>"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.1.0",
+    "command": "dotnet",
+    "isShellCommand": true,
+    "args": [],
+    "tasks": [
+        {
+            "taskName": "build",
+            "args": [],
+            "isBuildCommand": true,
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Mvc;
 
 using AspNetCorePostgreSQLDockerApp.Repository;
 
@@ -10,13 +10,13 @@ namespace AspNetCorePostgreSQLDockerApp.Controllers
 {
     public class HomeController : Controller
     {
-      
+
         IDockerCommandsRepository _repo;
-        
+
         public HomeController(IDockerCommandsRepository repo) {
           _repo = repo;
         }
-      
+
         public async Task<IActionResult> Index()
         {
             //Call into PostgreSQL

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM spboyer/dotnet-preview:1.0.0-rc2-002697
+
+
+# Set environment variables
+ENV ASPNETCORE_URLS="http://*:5000"
+ENV ASPNETCORE_ENVIRONMENT="Staging"
+
+# Copy files to app directory
+COPY . /app
+
+# Set working directory
+WORKDIR /app
+
+# Restore NuGet packages
+RUN ["dotnet", "restore"]
+
+# Open up port
+EXPOSE 5000
+
+# Run the app
+ENTRYPOINT ["dotnet", "run"]

--- a/Migrations/20160213220647_FunWithDocker.Designer.cs
+++ b/Migrations/20160213220647_FunWithDocker.Designer.cs
@@ -1,8 +1,8 @@
 using System;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Metadata;
-using Microsoft.Data.Entity.Migrations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using AspNetCorePostgreSQLDockerApp.Repository;
 
 namespace AspNetCorePostgreSQLDockerApp.Migrations

--- a/Migrations/20160213220647_FunWithDocker.cs
+++ b/Migrations/20160213220647_FunWithDocker.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace AspNetCorePostgreSQLDockerApp.Migrations
 {

--- a/Migrations/DockerCommandsDbContextModelSnapshot.cs
+++ b/Migrations/DockerCommandsDbContextModelSnapshot.cs
@@ -1,8 +1,8 @@
 using System;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Metadata;
-using Microsoft.Data.Entity.Migrations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using AspNetCorePostgreSQLDockerApp.Repository;
 
 namespace AspNetCorePostgreSQLDockerApp.Migrations

--- a/Program.cs
+++ b/Program.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+
+namespace AspNetCorePostgreSQLDockerApp
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            // Get environment variables
+            var config = new ConfigurationBuilder()
+                .AddEnvironmentVariables("")
+                .Build();
+            var url = config["ASPNETCORE_URLS"] ?? "http://*:5000";
+            var env = config["ASPNETCORE_ENVIRONMENT"] ?? "Development";
+
+            var host = new WebHostBuilder()
+                        .UseKestrel()
+                        .UseUrls(url)
+                        .UseEnvironment(env)
+                        .UseIISIntegration()
+                        .UseContentRoot(Directory.GetCurrentDirectory())
+                        .UseStartup<Startup>()
+                        .Build();
+            host.Run();
+        }
+    }
+}

--- a/Repository/DbSeeder.cs
+++ b/Repository/DbSeeder.cs
@@ -1,4 +1,4 @@
-using Microsoft.Data.Entity;
+using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -23,7 +23,7 @@ namespace AspNetCorePostgreSQLDockerApp.Repository
         }
 
         public async Task SeedAsync(IServiceProvider serviceProvider)
-        {           
+        {
             //Based on EF team's example at https://github.com/aspnet/MusicStore/blob/dev/src/MusicStore/Models/SampleData.cs#L23
             using (var serviceScope = serviceProvider.GetRequiredService<IServiceScopeFactory>().CreateScope())
             {
@@ -33,27 +33,27 @@ namespace AspNetCorePostgreSQLDockerApp.Repository
                 {
                     if (!await db.DockerCommands.AnyAsync()) {
                       await InsertSampleData(db);
-                    }                    
+                    }
                 }
             }
         }
 
         public async Task InsertSampleData(DockerCommandsDbContext db)
         {
-            var commands = GetDockerCommands();  
+            var commands = GetDockerCommands();
             db.DockerCommands.AddRange(commands);
-            
+
             try
             {
               await db.SaveChangesAsync();
             }
             catch (Exception exp)
             {
-              _logger.LogError($"Error in {nameof(DbSeeder)}: " + exp.Message);              
+              _logger.LogError($"Error in {nameof(DbSeeder)}: " + exp.Message);
             }
-            
+
         }
-        
+
         private List<DockerCommand> GetDockerCommands()
         {
             var cmd1 = new DockerCommand {
@@ -70,7 +70,7 @@ namespace AspNetCorePostgreSQLDockerApp.Repository
                     }
                 }
             };
-            
+
             var cmd2 = new DockerCommand {
                 Command = "ps",
                 Description = "Lists containers",
@@ -85,7 +85,7 @@ namespace AspNetCorePostgreSQLDockerApp.Repository
                     }
                 }
             };
-            
+
             return new List<DockerCommand> { cmd1, cmd2 };
         }
     }

--- a/Repository/DockerCommandsDbContext.cs
+++ b/Repository/DockerCommandsDbContext.cs
@@ -1,10 +1,11 @@
-using Microsoft.Data.Entity;
+using Microsoft.EntityFrameworkCore;
 using AspNetCorePostgreSQLDockerApp.Models;
 
 namespace AspNetCorePostgreSQLDockerApp.Repository
 {
     public class DockerCommandsDbContext : DbContext
     {
+        public DockerCommandsDbContext(DbContextOptions options) : base(options) { }
         public DbSet<DockerCommand> DockerCommands { get; set; }
     }
 }

--- a/Repository/DockerCommandsRepository.cs
+++ b/Repository/DockerCommandsRepository.cs
@@ -1,5 +1,5 @@
 using System;
-using Microsoft.Data.Entity;
+using Microsoft.EntityFrameworkCore;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -13,16 +13,16 @@ namespace AspNetCorePostgreSQLDockerApp.Repository
     {
         private readonly DockerCommandsDbContext _context;
         private readonly ILogger _logger;
-      
+
         public DockerCommandsRepository(DockerCommandsDbContext context, ILoggerFactory loggerFactory) {
           _context = context;
           _logger = loggerFactory.CreateLogger("DockerCommandsRepository");
         }
-      
+
         public async Task<List<DockerCommand>> GetDockerCommandsAsync() {
           return await _context.DockerCommands.Include(dc => dc.Examples).ToListAsync();
         }
-        
+
         public async Task InsertDockerCommandAsync(DockerCommand command) {
           _context.DockerCommands.Add(command);
           try {

--- a/Views/_ViewImports.cshtml
+++ b/Views/_ViewImports.cshtml
@@ -1,3 +1,3 @@
 @using AspNetCorePostgreSQLDockerApp
 @using AspNetCorePostgreSQLDockerApp.Models
-@addTagHelper *, Microsoft.AspNet.Mvc.TagHelpers
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/appsettings.json
+++ b/appsettings.json
@@ -9,7 +9,9 @@
   },
   "Data": {
     "DockerCommandsDbContext": {
+      "LocalConnectionString":  "User ID=<YourUserName>;Password=;Server=127.0.0.1;Port=5432;Database=<YourUserName>;Pooling=true;",
       "ConnectionString":  "User ID=postgres;Password=password;Server=postgres;Port=5432;Database=POSTGRES_USER;Integrated Security=true;Pooling=true;"
+
     }
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,14 @@ version: '2'
 services:
 
   web:
-    build: 
+    build:
       context: .
-      dockerfile: aspnetcore.dockerfile
+      dockerfile: Dockerfile
     ports:
      - "5000:5000"
     networks:
       - aspnetcoreapp-network
-      
+
   postgres:
     image: postgres
     environment:

--- a/dotnet-preview.dockerfile
+++ b/dotnet-preview.dockerfile
@@ -1,0 +1,24 @@
+# NOTE: Set the DOTNET_VERSION environment variable to the desired version.
+
+# Build the image:
+# docker build -t spboyer/dotnet-preview:1.0.0-rc2-002697 .
+# docker push 
+
+FROM buildpack-deps:trusty-scm
+
+MAINTAINER Shayne Boyer
+
+# DotNet CLI version
+ENV DOTNET_VERSION=1.0.0-preview1-002697
+
+# Work around https://github.com/dotnet/cli/issues/1582 until Docker releases a
+# fix (https://github.com/docker/docker/issues/20818). This workaround allows
+# the container to be run with the default seccomp Docker settings by avoiding
+# the restart_syscall made by LTTng which causes a failed assertion.
+ENV LTTNG_UST_REGISTER_TIMEOUT 0
+
+RUN echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list \
+    && apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893 \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends dotnet-dev-${DOTNET_VERSION} \
+    && rm -rf /var/lib/apt/lists/*

--- a/hosting.json
+++ b/hosting.json
@@ -1,4 +1,0 @@
-{
-    "server": "Microsoft.AspNet.Server.Kestrel",
-    "server.urls": "http://0.0.0.0:5000"
-}

--- a/nuget.config
+++ b/nuget.config
@@ -2,8 +2,8 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="NuGet" value="https://nuget.org/api/v2/" />
-    <add key="AspNetVNext" value="https://www.myget.org/F/aspnetvnext/" />
+    <add key="AspNetCI" value="https://www.myget.org/F/aspnetcirelease/api/v3/index.json" />
+    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
     <add key="NpgsqlUnstable" value="https://www.myget.org/F/npgsql-unstable/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/project.json
+++ b/project.json
@@ -1,63 +1,62 @@
 {
-  "version": "1.0.0-*",
-  "compilationOptions": {
-    "emitEntryPoint": true
-  },
-  "tooling": {
-    "defaultNamespace": "AspNetCorePostgreSQLDockerApp"
-  },
+    "version": "1.0.0-*",
+    "buildOptions": {
+        "preserveCompilationContext": true,
+        "emitEntryPoint": true,
+        "debugType": "portable"
+    },
+    "publishOptions": {
+        "include": [
+            "wwwroot",
+            "Views"
+        ]
+    },
+    "dependencies": {
+        "Microsoft.NETCore.App": {
+            "type": "platform",
+            "version": "1.0.0-*"
+        },
+        "Microsoft.Extensions.Logging": "1.0.0-*",
+        "Microsoft.Extensions.Logging.Console": "1.0.0-*",
+        "Microsoft.Extensions.Logging.Debug": "1.0.0-*",
+        "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
+        "Microsoft.AspNetCore.Mvc": "1.0.0-*",
+        "Microsoft.AspNetCore.Mvc.Formatters.Json": "1.0.0-*",
+        "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+        "System.Runtime.Serialization.Primitives": "4.1.1-*",
+        "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
+        "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
+        "Microsoft.AspNetCore.Routing": "1.0.0-*",
+        "Microsoft.Extensions.Options.ConfigurationExtensions": "1.0.0-*",
+        "Microsoft.EntityFrameworkCore": "1.0.0-*",
+        "Microsoft.EntityFrameworkCore.SqlServer": "1.0.0-*",
+        "Microsoft.EntityFrameworkCore.Sqlite": "1.0.0-*",
+        "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-*",
+        "Microsoft.Extensions.Configuration.Json": "1.0.0-*",
+        "Npgsql.EntityFrameworkCore.PostgreSQL": "1.0.0-*"
 
-  "dependencies": {
-    "EntityFramework.Commands": "7.0.0-rc2-*",
-    "EntityFramework.Sqlite": "7.0.0-rc2-*",
-    "EntityFramework.MicrosoftSqlServer": "7.0.0-rc2-*",
-    "EntityFramework7.Npgsql": "3.1.0-unstable0415",
-    "Microsoft.AspNet.Authentication.Cookies": "1.0.0-rc2-*",
-    "Microsoft.AspNet.Diagnostics.Entity": "7.0.0-rc2-*",
-    "Microsoft.AspNet.Identity.EntityFramework": "3.0.0-rc2-*",
-    "Microsoft.AspNet.IISPlatformHandler": "1.0.0-rc2-*",
-    "Microsoft.AspNet.Mvc": "6.0.0-rc2-*",
-    "Microsoft.AspNet.Mvc.TagHelpers": "6.0.0-rc2-*",
-    "Microsoft.AspNet.Server.Kestrel": "1.0.0-rc2-*",
-    "Microsoft.AspNet.Hosting": "1.0.0-rc2-*",
-    "Microsoft.AspNet.StaticFiles": "1.0.0-rc2-*",
-    "Microsoft.AspNet.Tooling.Razor": "1.0.0-rc2-*",
-    "Microsoft.Dnx.Runtime":"1.0.0-rc2-*",
-    "Microsoft.Extensions.CodeGenerators.Mvc": "1.0.0-rc2-*",
-    "Microsoft.Extensions.Configuration.FileProviderExtensions" : "1.0.0-rc2-*",
-    "Microsoft.Extensions.Configuration.Json": "1.0.0-rc2-*",
-    "Microsoft.Extensions.Configuration.UserSecrets": "1.0.0-rc2-*",
-    "Microsoft.Extensions.Logging": "1.0.0-rc2-*",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-*",
-    "Microsoft.Extensions.Logging.Debug": "1.0.0-rc2-*",
-    "runtime.linux.System.Net.NetworkInformation": "4.1.0-beta-*",
-    "runtime.unix.System.Net.Security": "4.0.0-beta-23516"
-  },
-
-  "commands": {
-    "web": "AspNetCorePostgreSQLDockerApp",
-    "ef": "EntityFramework.Commands"
-  },
-
-  "frameworks": {
-    "dnxcore50": { }
-  },
-
-  "exclude": [
-    "wwwroot",
-    "node_modules",
-    "bower_components"
-  ],
-  "publishExclude": [
-    "**.user",
-    "**.vspscc"
-  ],
-  "scripts": {
-    "prepublish": [
-      "npm install",
-      "bower install",
-      "gulp clean",
-      "gulp min"
-    ]
-  }
+    },
+    "frameworks": {
+        "netcoreapp1.0": {
+            "imports": [
+                "portable-net45+wp80+win8+wpa81+dnxcore50",
+                "portable-net452+win81"
+            ]
+        }
+    },
+    "tools": {
+        "Microsoft.AspNetCore.Server.IISIntegration.Tools": {
+            "version": "1.0.0-*",
+            "imports": "portable-net45+wp80+win8+wpa81+dnxcore50"
+        }
+    },
+    "scripts": {
+        "prepublish": [
+            "npm install",
+            "bower install",
+            "gulp clean",
+            "gulp min"
+        ],
+        "postpublish": "dotnet publish-iis --publish-folder %publish:OutputPath% --framework %publish:FullTargetFramework%"
+    }
 }

--- a/project.json.old
+++ b/project.json.old
@@ -1,0 +1,63 @@
+{
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "tooling": {
+    "defaultNamespace": "AspNetCorePostgreSQLDockerApp"
+  },
+
+  "dependencies": {
+    "EntityFramework.Commands": "7.0.0-rc2-*",
+    "EntityFramework.Sqlite": "7.0.0-rc2-*",
+    "EntityFramework.MicrosoftSqlServer": "7.0.0-rc2-*",
+    "EntityFramework7.Npgsql": "3.1.0-unstable0415",
+    "Microsoft.AspNet.Authentication.Cookies": "1.0.0-rc2-*",
+    "Microsoft.AspNet.Diagnostics.Entity": "7.0.0-rc2-*",
+    "Microsoft.AspNet.Identity.EntityFramework": "3.0.0-rc2-*",
+    "Microsoft.AspNet.IISPlatformHandler": "1.0.0-rc2-*",
+    "Microsoft.AspNet.Mvc": "6.0.0-rc2-*",
+    "Microsoft.AspNet.Mvc.TagHelpers": "6.0.0-rc2-*",
+    "Microsoft.AspNet.Server.Kestrel": "1.0.0-rc2-*",
+    "Microsoft.AspNet.Hosting": "1.0.0-rc2-*",
+    "Microsoft.AspNet.StaticFiles": "1.0.0-rc2-*",
+    "Microsoft.AspNet.Tooling.Razor": "1.0.0-rc2-*",
+    "Microsoft.Dnx.Runtime":"1.0.0-rc2-*",
+    "Microsoft.Extensions.CodeGenerators.Mvc": "1.0.0-rc2-*",
+    "Microsoft.Extensions.Configuration.FileProviderExtensions" : "1.0.0-rc2-*",
+    "Microsoft.Extensions.Configuration.Json": "1.0.0-rc2-*",
+    "Microsoft.Extensions.Configuration.UserSecrets": "1.0.0-rc2-*",
+    "Microsoft.Extensions.Logging": "1.0.0-rc2-*",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-*",
+    "Microsoft.Extensions.Logging.Debug": "1.0.0-rc2-*",
+    "runtime.linux.System.Net.NetworkInformation": "4.1.0-beta-*",
+    "runtime.unix.System.Net.Security": "4.0.0-beta-23516"
+  },
+
+  "commands": {
+    "web": "AspNetCorePostgreSQLDockerApp",
+    "ef": "EntityFramework.Commands"
+  },
+
+  "frameworks": {
+    "dnxcore50": { }
+  },
+
+  "exclude": [
+    "wwwroot",
+    "node_modules",
+    "bower_components"
+  ],
+  "publishExclude": [
+    "**.user",
+    "**.vspscc"
+  ],
+  "scripts": {
+    "prepublish": [
+      "npm install",
+      "bower install",
+      "gulp clean",
+      "gulp min"
+    ]
+  }
+}


### PR DESCRIPTION
Upgrade complete

add new base image dockerfile dotnet-preview.dockerfile
added new Dockerfile, pulls from new base image spboyer/dotnet-preview:1.0.0-rc2-002697
added LocalConnectionString to appsettings
Program.cs add for RC2
nuget.config feeds updated for RC1, PostgreSQL
Resources

NuGet Feed - need to clear usr/dotnet/nuget/packages for collisions with old packages
https://github.com/aspnet/Home/wiki/NuGet-feeds
aspnet/Home#1381
http://apt-mo.trafficmanager.net/repos/dotnet/pool/main/d/ - for debian dotnet versions and tags
https://github.com/dotnet/cli - install runtime and SDK